### PR TITLE
Lxde: packages-systemd.yaml - remove yaourt

### DIFF
--- a/lxde/packages-systemd.yaml
+++ b/lxde/packages-systemd.yaml
@@ -58,7 +58,6 @@
   packages:
         - pacui
         - mhwd-tui
-        - yaourt
         - powertop
         - htop
         - mlocate      


### PR DESCRIPTION
Remove **yaourt** from CLI apps since I included it in the base installation.